### PR TITLE
Add TSC members as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @krisfreedain @dblock
+*   @krisfreedain @dblock @amistrn @anastead @andrross @reta @austintlee @bryanlb @elfisher @jkowall @KarstenSchnitter @Pallavi-AWS @samuel-oci @guptashubham @yoelee @yupeng9

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,21 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer           | GitHub ID                                           | Affiliation |
-|----------------------|-----------------------------------------------------|-------------|
-| Kris Freedain        | [krisfreedain](https://github.com/krisfreedain)     | Amazon      |
-| Daniel Doubrovkine   | [dblock](https://github.com/dblock)                 | Amazon      |
+| Maintainer                | GitHub ID                                           | Affiliation |
+|---------------------------|-----------------------------------------------------|-------------|
+| Kris Freedain             | [krisfreedain](https://github.com/krisfreedain)     | Amazon      |
+| Daniel Doubrovkine        | [dblock](https://github.com/dblock)                 | Amazon      |
+| Amitai Stern              | [amistrn](https://github.com/amistrn)               | Logz.io     |
+| Anandhi Bumstead          | [anastead](https://github.com/anastead)             | AWS         |
+| Andrew Ross               | [andrross](https://github.com/andrross)             | AWS         |
+| Andriy Redko              | [reta](https://github.com/reta)                     | Aiven       |
+| Austin Lee                | [austintlee](https://github.com/austintlee)         | Aryn        |
+| Bryan Burkholder          | [bryanlb](https://github.com/bryanlb)               | Slack/Salesforce |
+| Eli Fisher                | [elfisher](https://github.com/elfisher)             | AWS         |
+| Jonah Kowall              | [jkowall](https://github.com/jkowall)               | Independent |
+| Karsten Schnitter         | [KarstenSchnitter](https://github.com/KarstenSchnitter) | SAP    |
+| Pallavi Priyadarshini     | [Pallavi-AWS](https://github.com/Pallavi-AWS)       | AWS         |
+| Samuel Herman             | [samuel-oci](https://github.com/samuel-oci/)        | Oracle      |
+| Shubham Gupta             | [guptashubham](https://github.com/guptashubham)     | Uber        |
+| Yakun Li                  | [yoelee](https://github.com/yoelee)                 | Bytedance   |
+| Yupeng Fu                 | [yupeng9](https://github.com/yupeng9)               | Uber        |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,17 +9,17 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer                | GitHub ID                                           | Affiliation |
 |---------------------------|-----------------------------------------------------|-------------|
-| Kris Freedain             | [krisfreedain](https://github.com/krisfreedain)     | Amazon      |
-| Daniel Doubrovkine        | [dblock](https://github.com/dblock)                 | Amazon      |
 | Amitai Stern              | [amistrn](https://github.com/amistrn)               | Logz.io     |
 | Anandhi Bumstead          | [anastead](https://github.com/anastead)             | AWS         |
 | Andrew Ross               | [andrross](https://github.com/andrross)             | AWS         |
 | Andriy Redko              | [reta](https://github.com/reta)                     | Aiven       |
 | Austin Lee                | [austintlee](https://github.com/austintlee)         | Aryn        |
 | Bryan Burkholder          | [bryanlb](https://github.com/bryanlb)               | Slack/Salesforce |
+| Daniel Doubrovkine        | [dblock](https://github.com/dblock)                 | Amazon      |
 | Eli Fisher                | [elfisher](https://github.com/elfisher)             | AWS         |
 | Jonah Kowall              | [jkowall](https://github.com/jkowall)               | Independent |
 | Karsten Schnitter         | [KarstenSchnitter](https://github.com/KarstenSchnitter) | SAP    |
+| Kris Freedain             | [krisfreedain](https://github.com/krisfreedain)     | Amazon      |
 | Pallavi Priyadarshini     | [Pallavi-AWS](https://github.com/Pallavi-AWS)       | AWS         |
 | Samuel Herman             | [samuel-oci](https://github.com/samuel-oci/)        | Oracle      |
 | Shubham Gupta             | [guptashubham](https://github.com/guptashubham)     | Uber        |


### PR DESCRIPTION
### Description
Add TSC members as MAINTAINERS - as discussed & approved in Oct 16 meeting

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
