### PR TITLE
Add bake time workflow

### DIFF
--- a/.github/workflows/bake_time.yml
+++ b/.github/workflows/bake_time.yml
@@ -1,0 +1,20 @@
+name: Bake time
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */1 * * *" # Runs every 1 hour
+
+jobs:
+  baking_pull_request:
+    name: "Baking pull request..."
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peternied/bake-time@v3.3
+        with:
+          check-name: "Baking pull request..."
+          delay-hours: 48


### PR DESCRIPTION
### Description
Adds the bake time workflow configured at 48 hours, similar to that as configured in the [opensearch-project .github repo](https://github.com/opensearch-project/.github/blob/main/.github/workflows/bake_time.yml). This requires new PRs to wait at least 48 hours before merging, once this workflow is made a required test by the repo admins.

### Issues Resolved
Closes #7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
