### PR TITLE
Charter link updaates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo is the home of the OpenSearch Project Technical Steering Committee (TS
 The OpenSearch Software Foundation Technical Steering Committee (TSC) aims to uphold and enhance the technical direction of the OpenSearch Project, benefiting the entire OpenSearch community. 
 
 * [Members](MEMBERS.md)
-* [Charter](https://foundation.opensearch.org/assets/media/OpenSearch%20Project%20Technical%20Charter%20Final%209-13-2024.docx.pdf)
+* [Charter](https://opensearch.org/wp-content/uploads/2025/02/OpenSearch-Project-Technical-Charter-Final-9-13-2024.docx.pdf)
 
 ## Special Interest Groups
 

--- a/special-interest-groups/build-interest-group/charter.md
+++ b/special-interest-groups/build-interest-group/charter.md
@@ -8,7 +8,7 @@ The OpenSearch Project, following Technical Steering Committee (TSC) recommendat
 
 * Initiate a review of the new repository's proposal / RFC / Issue through a [new repository request](https://github.com/opensearch-project/.github/issues/new?template=REPOSITORY_REQUEST_TEMPLATE.yaml)
   * Based on [these categories](https://github.com/opensearch-project/.github/issues/296)
-* Ensure new repositories align with the foundation’s [charter](https://foundation.opensearch.org/assets/media/OpenSearch%20Project%20Technical%20Charter%20Final%209-13-2024.docx.pdf)
+* Ensure new repositories align with the foundation’s [charter](https://opensearch.org/wp-content/uploads/2025/02/OpenSearch-Project-Technical-Charter-Final-9-13-2024.docx.pdf)
 * Review by a subject matter expert (SME) on the proposal
   * For example, BIG will help contact maintainers from ml-commons repository to review machine learning, neural search, and k-NN related proposals
 * Review the naming, proposal topic, and code (if available) in detail


### PR DESCRIPTION
### Description
Updating link to the foundation charter document in the readme and build interest group charter. 

### Issues Resolved
https://github.com/opensearch-project/technical-steering/issues/36


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
