### PR TITLE
add to observability sig

### DIFF
--- a/special-interest-groups/observability-tag/README.md
+++ b/special-interest-groups/observability-tag/README.md
@@ -17,6 +17,7 @@ We follow the membership guidelines proposed in [SIGs README](../README.md) to a
 | Shenoy Pratik Gurudatt | [@ps48](https://github.com/ps48)                         | Amazon      |
 | Dotan Horovits         | [@horovits](https://github.com/horovits)                 | Amazon      |
 | Jonah Kowall           | [@jkowall](https://github.com/jkowall)                   | Paessler    |
+| Seth Muthukaruppan     | [@smuthuka](https://github.com/smuthuka)                 | NetApp      |
 | Karsten Schnitter      | [@KarstenSchnitter](https://github.com/KarstenSchnitter) | SAP         |
 | Mikhail Stepura        | [@Mishail](https://github.com/Mishail)                   | Apple       |
 | Jürgen Walter          | [@juergen-walter](https://github.com/juergen-walter)     | SAP         |


### PR DESCRIPTION
### Description
As part of the NetApp team, we specialize in helping our customers design, build, and operate production-grade open-source observability platforms leveraging OpenTelemetry for collecting distributed traces, metrics, and logs. We assist in optimizing OpenTelemetry pipelines through tailored configuration and tuning of data collectors for efficient observability. Our observability pipelines support open-source backends such as OpenSearch and ClickHouse.

### Issues
Related to [Forming OpenSearch Observability SIG](https://github.com/opensearch-project/technical-steering/issues/40)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
