### PR TITLE
Fix CoC links in TAG charters

### DIFF
--- a/technical-advisory-groups/build-tag/charter.md
+++ b/technical-advisory-groups/build-tag/charter.md
@@ -35,7 +35,7 @@ The OpenSearch Project, following Technical Steering Committee (TSC) recommendat
     * Securing OpenSearch environments, managing alerts, and compliance with security standards
   * **Release Management**
     * Release process, infrastructure, system related experts
-* Follow the OpenSearch Software Foundation’s Code of Conduct.
+* Follow the OpenSearch Software Foundation’s [Code of Conduct](https://github.com/opensearch-project/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Communications
 

--- a/technical-advisory-groups/observability-tag/charter.md
+++ b/technical-advisory-groups/observability-tag/charter.md
@@ -23,7 +23,7 @@ The following is a non-exhaustive sample list of activities and deliverables tha
 
 ### Participation
 
-All participants must adhere to the OpenSearch Software Foundation’s Code of Conduct and the SIG’s operational guidelines to foster a respectful and inclusive environment.
+All participants must adhere to the OpenSearch Software Foundation’s [Code of Conduct](https://github.com/opensearch-project/.github/blob/main/CODE_OF_CONDUCT.md) and the SIG’s operational guidelines to foster a respectful and inclusive environment.
 
 #### Eligibility
 

--- a/technical-advisory-groups/security-tag/charter.md
+++ b/technical-advisory-groups/security-tag/charter.md
@@ -23,7 +23,7 @@ The following is a non-exhaustive sample list of activities and deliverables tha
 
 ### Participation
 
-All participants must adhere to the [OSSF Code of Conduct](https://openssf.org/community/code-of-conduct/) and the TAG’s operational guidelines to foster a respectful, inclusive, and transparent environment.
+All participants must adhere to the [OSSF Code of Conduct](https://github.com/opensearch-project/.github/blob/main/CODE_OF_CONDUCT.md) and the TAG’s operational guidelines to foster a respectful, inclusive, and transparent environment.
 
 #### Eligibility
 


### PR DESCRIPTION
### Description
Security TAG charter incorrectly linked to the OpenSSF CoC file - fixed to link it to the OpenSearch Software Foundation CoC
Added links to CoC in Build and Observability charters for consistency 

### Issues Resolved
n/a 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
