### PR TITLE
Add Trey and Dom to Search TAG

### DIFF
--- a/technical-advisory-groups/search-tag/README.md
+++ b/technical-advisory-groups/search-tag/README.md
@@ -36,4 +36,4 @@ We follow the membership guidelines proposed in [TAGs README](../README.md) to a
 | Monika Leoster         | [@monikaleoster](https://github.com/monikaleoster) | Community              |
 | Vigya Sharma           | [@vigyasharma](https://github.com/vigyasharma) | Amazon                 |
 | Trey Grainger           | [@treygrainger](https://github.com/treygrainger) | SearchKernel                 |
-| Dom Couldwell           |  | IBM                 |
+| Dom Couldwell           | [@DomCouldwell](https://github.com/DomCouldwell) | IBM                 |

--- a/technical-advisory-groups/search-tag/README.md
+++ b/technical-advisory-groups/search-tag/README.md
@@ -36,4 +36,4 @@ We follow the membership guidelines proposed in [TAGs README](../README.md) to a
 | Monika Leoster         | [@monikaleoster](https://github.com/monikaleoster) | Community              |
 | Vigya Sharma           | [@vigyasharma](https://github.com/vigyasharma) | Amazon                 |
 | Trey Grainger           | [@treygrainger](https://github.com/treygrainger) | SearchKernel                 |
-| Dom Cauldwell           |  | IBM                 |
+| Dom Couldwell           |  | IBM                 |

--- a/technical-advisory-groups/search-tag/README.md
+++ b/technical-advisory-groups/search-tag/README.md
@@ -35,3 +35,5 @@ We follow the membership guidelines proposed in [TAGs README](../README.md) to a
 | Marc Handalian         | [@mch2](https://github.com/mch2) | Amazon                 |
 | Monika Leoster         | [@monikaleoster](https://github.com/monikaleoster) | Community              |
 | Vigya Sharma           | [@vigyasharma](https://github.com/vigyasharma) | Amazon                 |
+| Trey Grainger           | [@treygrainger](https://github.com/treygrainger) | SearchKernel                 |
+| Dom Cauldwell           |  | IBM                 |


### PR DESCRIPTION
### Description
We are adding two folks to the Search TAG

1) Following a nomination process, in accordance with the [TAG governance](https://github.com/opensearch-project/technical-steering/blob/main/technical-advisory-groups/README.md#adding-a-member), member Dom Couldwell got accepted as a TAG member. 

2) Trey Grainger was in the initial batch establishing the tag, but was missed in being listed on the Search TAG README.  This oversight is being fixed.

This PR updates the membership to reflect it on the TAG charter.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
