### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/bake_time.yml
+++ b/.github/workflows/bake_time.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Baking pull request..."
     runs-on: ubuntu-latest
     steps:
-      - uses: peternied/bake-time@v3.3
+      - uses: peternied/bake-time@9b5f238efbc819d822ad770c7cf9b90ebbffa450 # v3.3
         with:
           check-name: "Baking pull request..."
           delay-hours: 48


### PR DESCRIPTION
### Description

Pin all GitHub Action tag references to their corresponding commit SHAs.

Tags are mutable references that can be force-pushed to point to different commits, making them vulnerable to supply chain attacks. Commit SHAs are immutable and guarantee that the exact reviewed code is executed in CI workflows. This change pins all third-party actions to their current commit SHAs to prevent potential tampering.