### PR TITLE
Update bake time action to use SHA commits

### DIFF
--- a/.github/workflows/bake_time.yml
+++ b/.github/workflows/bake_time.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Baking pull request..."
     runs-on: ubuntu-latest
     steps:
-      - uses: peternied/bake-time@9b5f238efbc819d822ad770c7cf9b90ebbffa450 # v3.3
+      - uses: peternied/bake-time@1a01d1e993bcaeba380d7ec84340c64fc586a754
         with:
           check-name: "Baking pull request..."
           delay-hours: 48


### PR DESCRIPTION
### Description
Fixes GHA to use SHA commits in upstream action.
Related PR: https://github.com/peternied/bake-time/pull/15

### Issues Resolved
https://github.com/opensearch-project/technical-steering/actions/runs/29274817018

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
