### PR TITLE
Add missing permission to bake time workflow

### DIFF
--- a/.github/workflows/bake_time.yml
+++ b/.github/workflows/bake_time.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 */1 * * *" # Runs every 1 hour
 
+permissions:
+  checks: write
+
 jobs:
   baking_pull_request:
     name: "Baking pull request..."


### PR DESCRIPTION
### Description
Add missing permission to bake time workflow. Fixes:
```
Unhandled error: HttpError: Resource not accessible by integration
```

### Issues Resolved
https://github.com/opensearch-project/technical-steering/actions/runs/29444561206


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
